### PR TITLE
Fix #15: Vylepšení převodu souřadnic S-JTSK na WGS84 pmocí PROJ4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "axios": "0.19.0",
     "libxmljs": "^0.19.7",
     "nodemon": "2.0.1",
+    "proj4": "^2.6.1",
     "ts-node": "8.5.3",
     "typescript": "3.7.2",
     "xml-js": "1.6.11"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/proj4": "^2.5.0",
     "jest": "^25.2.7",
     "prettier": "1.19.1",
     "ts-jest": "^25.3.1"

--- a/src/ruian.ts
+++ b/src/ruian.ts
@@ -1,17 +1,14 @@
 import axios from "axios";
 import proj4 from "proj4";
 
-export type WGS84 = { _type: "WGS84" };
-export type S_JTSK = { _type: "S-JTSK" };
-export type CoordinateSystem = WGS84 | S_JTSK;
-export type Location<T extends CoordinateSystem> = [number, number] & T;
+export type WGS84Location = [number, number]
 
 const ENDPOINT = "https://api.apitalks.store/cuzk.cz/adresni-mista-cr?";
 
 export async function getLocation(
   addressPoint: string,
   apiKey: string
-): Promise<Location<WGS84> | null> {
+): Promise<WGS84Location | null> {
   const response = await axios.get(ENDPOINT, {
     headers: {
       "x-api-key": apiKey
@@ -36,11 +33,10 @@ export async function getLocation(
   }
 }
 
-// TODO: Switch to proj4js instead.
 export function convertCoordinatesJtskToWgs(
   X: number,
   Y: number
-) : Location<WGS84> {
+) : WGS84Location {
   if (X < 0) {
     X = -X;
   }
@@ -55,5 +51,5 @@ export function convertCoordinatesJtskToWgs(
   );
 
   var point = proj4.transform(proj4.Proj("EPSG:5514"), proj4.Proj("WGS84"), proj4.toPoint([-Y, -X]));
-  return [point.y, point.x] as Location<WGS84>;
+  return [point.y, point.x] as WGS84Location;
 };

--- a/src/ruian.ts
+++ b/src/ruian.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import proj4 from "proj4";
 
 export type WGS84 = { _type: "WGS84" };
 export type S_JTSK = { _type: "S-JTSK" };
@@ -26,7 +27,7 @@ export async function getLocation(
     const x = parseFloat(items[0].SOURADNICE_X);
     const y = parseFloat(items[0].SOURADNICE_Y);
     if (x != null && y != null) {
-      return convertCoordinatesJtskToWgs(x, y, 0);
+      return convertCoordinatesJtskToWgs(x, y);
     } else {
       return null;
     }
@@ -38,130 +39,21 @@ export async function getLocation(
 // TODO: Switch to proj4js instead.
 export function convertCoordinatesJtskToWgs(
   X: number,
-  Y: number,
-  H: number
-): Location<WGS84> {
-  if (X < 0 && Y < 0) {
+  Y: number
+) : Location<WGS84> {
+  if (X < 0) {
     X = -X;
+  }
+  if (Y < 0) {
     Y = -Y;
   }
-  var coord = {
-    wgs84_latitude: "",
-    wgs84_longitude: "",
-    lat: 0,
-    lon: 0,
-    vyska: 0
-  };
 
-  /* Přepočet vstupích údajů - vychazi z nejakeho skriptu, ktery jsem nasel na Internetu - nejsem autorem prepoctu. */
+  proj4.defs("EPSG:5514", 
+     "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 "
+   + "+k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=greenwich +units=m +no_defs"
+   + "+towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56"
+  );
 
-  /*Vypocet zemepisnych souradnic z rovinnych souradnic*/
-  let a = 6377397.15508;
-  const e = 0.081696831215303;
-  const n = 0.97992470462083;
-  const konst_u_ro = 12310230.12797036;
-  const sinUQ = 0.863499969506341;
-  const cosUQ = 0.504348889819882;
-  const sinVQ = 0.420215144586493;
-  const cosVQ = 0.907424504992097;
-  const alfa = 1.000597498371542;
-  const k = 1.003419163966575;
-  let ro = Math.sqrt(X * X + Y * Y);
-  const epsilon = 2 * Math.atan(Y / (ro + X));
-  const D = epsilon / n;
-  const S =
-    2 * Math.atan(Math.exp((1 / n) * Math.log(konst_u_ro / ro))) - Math.PI / 2;
-  const sinS = Math.sin(S);
-  const cosS = Math.cos(S);
-  const sinU = sinUQ * sinS - cosUQ * cosS * Math.cos(D);
-  const cosU = Math.sqrt(1 - sinU * sinU);
-  const sinDV = (Math.sin(D) * cosS) / cosU;
-  const cosDV = Math.sqrt(1 - sinDV * sinDV);
-  const sinV = sinVQ * cosDV - cosVQ * sinDV;
-  const cosV = cosVQ * cosDV + sinVQ * sinDV;
-  const Ljtsk = (2 * Math.atan(sinV / (1 + cosV))) / alfa;
-  let t = Math.exp((2 / alfa) * Math.log((1 + sinU) / cosU / k));
-  let pom = (t - 1) / (t + 1);
-  let sinB;
-  do {
-    sinB = pom;
-    pom = t * Math.exp(e * Math.log((1 + e * sinB) / (1 - e * sinB)));
-    pom = (pom - 1) / (pom + 1);
-  } while (Math.abs(pom - sinB) > 1e-15);
-
-  const Bjtsk = Math.atan(pom / Math.sqrt(1 - pom * pom));
-
-  /* Pravoúhlé souřadnice ve S-JTSK */
-  a = 6377397.15508;
-  let f_1 = 299.152812853;
-  let e2 = 1 - (1 - 1 / f_1) * (1 - 1 / f_1);
-  ro = a / Math.sqrt(1 - e2 * Math.sin(Bjtsk) * Math.sin(Bjtsk));
-  const x = (ro + H) * Math.cos(Bjtsk) * Math.cos(Ljtsk);
-  const y = (ro + H) * Math.cos(Bjtsk) * Math.sin(Ljtsk);
-  const z = ((1 - e2) * ro + H) * Math.sin(Bjtsk);
-
-  /* Pravoúhlé souřadnice v WGS-84*/
-  const dx = 570.69;
-  const dy = 85.69;
-  const dz = 462.84;
-  const wz = ((-5.2611 / 3600) * Math.PI) / 180;
-  const wy = ((-1.58676 / 3600) * Math.PI) / 180;
-  const wx = ((-4.99821 / 3600) * Math.PI) / 180;
-  const m = 3.543e-6;
-  const xn = dx + (1 + m) * (x + wz * y - wy * z);
-  const yn = dy + (1 + m) * (-wz * x + y + wx * z);
-  const zn = dz + (1 + m) * (wy * x - wx * y + z);
-
-  /* Geodetické souřadnice v systému WGS-84*/
-  a = 6378137.0;
-  f_1 = 298.257223563;
-  const a_b = f_1 / (f_1 - 1);
-  const p = Math.sqrt(xn * xn + yn * yn);
-  e2 = 1 - (1 - 1 / f_1) * (1 - 1 / f_1);
-  const theta = Math.atan((zn * a_b) / p);
-  const st = Math.sin(theta);
-  const ct = Math.cos(theta);
-  t = (zn + e2 * a_b * a * st * st * st) / (p - e2 * a * ct * ct * ct);
-  let B = Math.atan(t);
-  let L = 2 * Math.atan(yn / (p + xn));
-  H = Math.sqrt(1 + t * t) * (p - a / Math.sqrt(1 + (1 - e2) * t * t));
-
-  /* Formát výstupních hodnot */
-
-  B = (B / Math.PI) * 180;
-
-  coord.lat = B;
-  let latitude = "N";
-  if (B < 0) {
-    B = -B;
-    latitude = "S";
-  }
-
-  const st_sirky = Math.floor(B);
-  B = (B - st_sirky) * 60;
-  const min_sirky = Math.floor(B);
-  B = (B - min_sirky) * 60;
-  const vt_sirky = Math.round(B * 1000) / 1000;
-  latitude = st_sirky + "°" + min_sirky + "'" + vt_sirky + latitude;
-  coord.wgs84_latitude = latitude;
-
-  L = (L / Math.PI) * 180;
-  coord.lon = L;
-  let longitude = "E";
-  if (L < 0) {
-    L = -L;
-    longitude = "W";
-  }
-
-  const st_delky = Math.floor(L);
-  L = (L - st_delky) * 60;
-  const min_delky = Math.floor(L);
-  L = (L - min_delky) * 60;
-  const vt_delky = Math.round(L * 1000) / 1000;
-  longitude = st_delky + "°" + min_delky + "'" + vt_delky + longitude;
-  coord.wgs84_longitude = longitude;
-
-  coord.vyska = Math.round(H * 100) / 100;
-
-  return [coord.lat, coord.lon] as Location<WGS84>;
-}
+  var point = proj4.transform(proj4.Proj("EPSG:5514"), proj4.Proj("WGS84"), proj4.toPoint([-Y, -X]));
+  return [point.y, point.x] as Location<WGS84>;
+};

--- a/tests/ruian.test.ts
+++ b/tests/ruian.test.ts
@@ -1,0 +1,42 @@
+import {
+  convertCoordinatesJtskToWgs
+} from "../src/ruian";
+
+test("Project S-JTSK coordinates to WGS84 using positive coordinates.", () => {
+  const locations = [
+    {propose: [1057130.96, 624293.63], expect:[50.0950516, 16.0892499]}, // Borohrádek
+    {propose: [984393, 662822], expect:[50.7032552, 15.4298465]}, // Jablonec nad Jizerou
+  ];
+
+  for (const obj of locations) {
+    const point = convertCoordinatesJtskToWgs(obj.propose[0], obj.propose[1]);
+    expect(point[0]).toBeCloseTo(obj.expect[0], 3);
+    expect(point[1]).toBeCloseTo(obj.expect[1], 3);
+  }
+});
+
+test("Project S-JTSK coordinates to WGS84 using negative coordinates.", () => {
+  const locations = [
+    {propose: [-1105152.27, -452698.70], expect:[49.8168667, 18.5347505]}, // Stonava
+    {propose: [-1017745.93, -888791.65], expect:[50.1151255, 12.3506929]}, // Františkovy Lázně
+  ];
+
+  for (const obj of locations) {
+    const point = convertCoordinatesJtskToWgs(obj.propose[0], obj.propose[1]);
+    expect(point[0]).toBeCloseTo(obj.expect[0], 3);
+    expect(point[1]).toBeCloseTo(obj.expect[1], 3);
+  }
+});
+
+test("Project S-JTSK coordinates to WGS84 using mixed coordinates.", () => {
+    const locations = [
+        {propose: [-1046499.62, 740088.59], expect:[50.0598097, 14.4656112]}, // Prague
+        {propose: [1160842.70, -597998.01], expect:[49.1944937, 16.6103813]}, // Brno
+    ];
+
+    for (const obj of locations) {
+        const point = convertCoordinatesJtskToWgs(obj.propose[0], obj.propose[1]);
+        expect(point[0]).toBeCloseTo(obj.expect[0], 3);
+        expect(point[1]).toBeCloseTo(obj.expect[1], 3);
+    }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,6 +604,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/proj4@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/proj4/-/proj4-2.5.0.tgz#40f1ed1cb9ef66e442ab6e57eba32eadc0f0501a"
+  integrity sha512-9bR9qvg4wZE6UiIlmhodCOZ2r38SeN8T35SsmMDuIMfACxxaMvIwiwoTJnEA9f/KEhL+BQSuD+arbZucUzYu7w==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -2801,6 +2806,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+mgrs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
+  integrity sha1-+5FYjnjJACVnI5XLQLJffNatGCk=
+
 micromatch@4.x, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
@@ -3314,6 +3324,14 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+proj4@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.6.1.tgz#c07a32cd4a38a82515aae3b54363669896641dd6"
+  integrity sha512-RP5EcrfrLcARy+Zjjz1wIeqZzZdPtQNl685asHcwdU/MQ/dvydmf1XWM4mgok6wPaNsXZ8IFrM4qadO3g46PiQ==
+  dependencies:
+    mgrs "1.0.0"
+    wkt-parser "^1.2.4"
 
 prompts@^2.0.1:
   version "2.3.0"
@@ -4281,6 +4299,11 @@ widest-line@^2.0.0:
   integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
   dependencies:
     string-width "^2.1.1"
+
+wkt-parser@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.2.4.tgz#e42ba7b96f13aef82a2da9056e2d87da0fec5393"
+  integrity sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Úprava původního kódu převodu staženého z internetu z využitím knihovny `proj4`. (viz [komenář](https://github.com/cityvizor/cityvizor/commit/c5511e4f4f53b944006f70a0c3e56af6a66f6650#r36453235))

Zároveň byly přidané testy pro novou funkcionalitu.