### PR TITLE
Fix #18: Odstranění duplicitních emailů

### DIFF
--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -65,8 +65,9 @@ function parseAdresa(elem: Element): Adresa | null {
 }
 
 function parseEmails(elem: Element): string[] {
-  const elems = elem.find("xmlns:Email/xmlns:Polozka/xmlns:Email", namespace);
-  return elems.map(e => (e as Element).text());
+  const emails = elem.find("xmlns:Email/xmlns:Polozka/xmlns:Email", namespace);
+  const elems = emails.map(e => (e as Element).text())
+  return elems.filter((item, index) => elems.indexOf(item) === index)
 }
 
 function parseChildAttValue(elem: Element, childName: string): string | null {

--- a/tests/fixtures/boskovice_duplicit_emails.xml
+++ b/tests/fixtures/boskovice_duplicit_emails.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Subjekt xmlns="http://www.czechpoint.cz/spravadat/p/ovm/datafile/seznamovm/v1">
+    <Zkratka>Boskovice</Zkratka>
+    <ICO>00279978</ICO>
+    <Nazev>Město Boskovice</Nazev>
+    <AdresaUradu>
+        <AdresniBod>15259641</AdresniBod>
+        <UliceNazev>Masarykovo náměstí</UliceNazev>
+        <CisloDomovni>4</CisloDomovni>
+        <CisloOrientacni>2</CisloOrientacni>
+        <ObecNazev>Boskovice</ObecNazev>
+        <ObecKod>581372</ObecKod>
+        <CastObceNeboKatastralniUzemi>Boskovice</CastObceNeboKatastralniUzemi>
+        <PSC>68001</PSC>
+        <KrajNazev>Jihomoravský</KrajNazev>
+    </AdresaUradu>
+    <Email>
+        <Polozka>
+            <Typ text="oficiální">1</Typ>
+            <Email>epodatelna@boskovice.cz</Email>
+        </Polozka>
+        <Polozka>
+            <Typ text="podatelna">2</Typ>
+            <Email>epodatelna@boskovice.cz</Email>
+        </Polozka>
+    </Email>
+    <TypSubjektu id="7">Obec III. Typu</TypSubjektu>
+    <PravniForma type="801">Obec</PravniForma>
+    <PrimarniOvm>Ano</PrimarniOvm>
+    <IdDS>qmkbq7h</IdDS>
+    <TypDS>OVM</TypDS>
+    <StavDS>1</StavDS>
+    <StavSubjektu>1</StavSubjektu>
+    <DetailSubjektu>https://www.czechpoint.cz/spravadat/p/ovm/datafile?format=xml&amp;service=seznamovm&amp;id=Boskovice</DetailSubjektu>
+    <IdentifikatorOvm>00279978</IdentifikatorOvm>
+    <KategorieOvm>KO101,KO108,KO11,KO126,KO13,KO136,KO137,KO14,KO157,KO16,KO163,KO167,KO17,KO171,KO177,KO178,KO180,KO193,KO197,KO199,KO200,KO242,KO261,KO303,KO341,KO342,KO382,KO421,KO423,KO424</KategorieOvm>
+</Subjekt>

--- a/tests/parsing.test.ts
+++ b/tests/parsing.test.ts
@@ -31,3 +31,30 @@ test("Parse single subject", () => {
     }
   });
 });
+
+test("Parse single subject with duplicated emails", () => {
+  const doc = parseFixture("boskovice_duplicit_emails.xml");
+  const subjekt = parseAllValidSubjects(doc)[0];
+  expect(subjekt).toEqual({
+    zkratka: "Boskovice",
+    ICO: "00279978",
+    nazev: "Město Boskovice",
+    datovaSchrankaID: "qmkbq7h",
+    mail: ["epodatelna@boskovice.cz"],
+    pravniForma: {
+      type: 801,
+      label: "Obec"
+    },
+    adresaUradu: {
+      PSC: "68001",
+      adresniBod: "15259641",
+      castObce: "Boskovice",
+      cisloDomovni: "4",
+      cisloOrientacni: "2",
+      kraj: "Jihomoravský",
+      obec: "Boskovice",
+      obecKod: "581372",
+      ulice: "Masarykovo náměstí"
+    }
+  });
+});


### PR DESCRIPTION
Při procházení dat mají některé obce stejný email uvedený jak pro
podatelnu tak pro oficiální komunikaci. Grabovací skript nerozlišuje
typ emailu a tak jednoduše odfiltrujeme zdvojené záznamy v emailech.