### PR TITLE
Přidání kroku pro stažení datasetu do README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Aktualizace je zatím náhodná, pravidelné generování viz [#2](https://githu
 * Kdybyste chtěli přispět (budeme moc rádi!), tak zdrojový kód a commity anglicky, všecko ostatní může být česky.
 
 ```bash
+$ wget -O all.xml.gz 'https://www.czechpoint.cz/spravadat/ovm/datafile.do?format=xml&service=seznamovm'
+$ gunzip all.xml.gz
 $ yarn install
 $ yarn test
 $ RUIAN_API_KEY=… LIMIT=10 yarn start

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { guessMunicipalityCOA } from "./coa";
 import { DataSource, addExtraData } from "./sources";
 import { parseXml } from "libxmljs";
 import { parseAllValidSubjects } from "./parsing";
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, existsSync} from "fs";
 import { Subjekt } from "./types";
 import { normalizeMunicipalityName } from "./naming";
 
@@ -110,4 +110,10 @@ const dataSources: DataSource<any>[] = [
   }
 ];
 
-convertData(dataSources, "all.xml");
+const DATA_FILE = "all.xml";
+if (existsSync(DATA_FILE)) {
+  convertData(dataSources, DATA_FILE);
+} else {
+  console.error(`The script requires presence of the dataset (${DATA_FILE})! Please download it and try again.`);
+}
+


### PR DESCRIPTION
Přidány kroky do README, které informují uživatelé o nutnosti stáhnout vstupní data.

Zároveň byla přidána kontrola, jestli soubor existuje. Místo stack-trace je tak uživatel vyzván ke stažení potřebných dat.