### PR TITLE
Chyba při nasazení pokud souřadnice jsou prázdný string

### DIFF
--- a/src/ruian.ts
+++ b/src/ruian.ts
@@ -19,18 +19,17 @@ export async function getLocation(
   });
 
   const items = response.data.data;
-
-  if (Array.isArray(items) && items.length > 0) {
-    const x = parseFloat(items[0].SOURADNICE_X);
-    const y = parseFloat(items[0].SOURADNICE_Y);
-    if (x != null && y != null) {
-      return convertCoordinatesJtskToWgs(x, y);
-    } else {
-      return null;
-    }
-  } else {
+  if (!Array.isArray(items) || !items.length) {
     return null;
   }
+
+  const x = Number(items[0].SOURADNICE_X);
+  const y = Number(items[0].SOURADNICE_Y);
+  if (isNaN(x) || isNaN(y)) {
+    return null;
+  }
+
+  return convertCoordinatesJtskToWgs(x, y);
 }
 
 export function convertCoordinatesJtskToWgs(


### PR DESCRIPTION
Předchozí kód ověřoval souřadnice porovnáním s `null` to však nestačilo a proklouzly skrz souřadnice, které byly vytvořené z prázdného řetězce (`NaN`).

Nový kód převádí čísla pomocí `Number()` místo původního `parseFloat()`, který by měl vždy vracet NaN v případě, že se převod nezdařil a proti NaN pak probíhá i následující ověření.